### PR TITLE
Add `yarn install` functionality

### DIFF
--- a/test/fixtures/example/content/package.json.njk
+++ b/test/fixtures/example/content/package.json.njk
@@ -1,6 +1,6 @@
 {
   "name": "{{project}}",
   "dependencies": {
-      "noop": "*"
+      "noop": "file:../fixtures/shared/noop"
   }
 }

--- a/test/fixtures/example/content/package.json.njk
+++ b/test/fixtures/example/content/package.json.njk
@@ -1,3 +1,6 @@
 {
-  "name": "{{project}}"
+  "name": "{{project}}",
+  "dependencies": {
+      "noop": "*"
+  }
 }

--- a/test/fixtures/shared/noop/index.js
+++ b/test/fixtures/shared/noop/index.js
@@ -1,0 +1,1 @@
+module.exports = function noop() {};

--- a/test/fixtures/shared/noop/package.json
+++ b/test/fixtures/shared/noop/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "noop",
+  "description": "noop",
+  "version": "0.0.0"
+}

--- a/test/index.js
+++ b/test/index.js
@@ -72,7 +72,7 @@ test('scaffolding example/', async t => {
   );
   t.ok(
     packageJsonContent ===
-      `{\n  "name": "foo",\n  "dependencies": {\n      "noop": "*"\n  }\n}\n`,
+      `{\n  "name": "foo",\n  "dependencies": {\n      "noop": "file:../fixtures/shared/noop"\n  }\n}\n`,
     '.njk files are compiled correctly'
   );
 

--- a/test/index.js
+++ b/test/index.js
@@ -71,7 +71,8 @@ test('scaffolding example/', async t => {
     'utf8'
   );
   t.ok(
-    packageJsonContent === `{\n  "name": "foo"\n}\n`,
+    packageJsonContent ===
+      `{\n  "name": "foo",\n  "dependencies": {\n      "noop": "*"\n  }\n}\n`,
     '.njk files are compiled correctly'
   );
 
@@ -97,6 +98,9 @@ test('scaffolding example/', async t => {
     ctxJsContent === "module.exports = 'bar';\n",
     'handles additional context from index.js correctly'
   );
+
+  const nodeModulesStat = await stat(join(projectDir, 'node_modules'));
+  t.ok(nodeModulesStat.isDirectory(), 'installs node_modules correctly');
 
   await rimraf(projectDir);
   await t.end();


### PR DESCRIPTION
This adds functionality to the scaffolder such that once the template is compiled, it will install the template's dependencies using `yarn`.

Fixes #17 