### PR TITLE
Update Windows yarn processes spawning

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,14 +114,20 @@ async function compile(projectPath, templatePath, contentPath, ctx) {
 async function install(projectPath) {
   return new Promise((resolve, reject) => {
     let child;
-    if (!/^win/.test(process.platform)) { // linux
+    if (!/^win/.test(process.platform)) {
+      // linux
       child = spawn('yarn', ['install', '--cwd', projectPath], {
         stdio: 'inherit',
       });
-    } else { // windows
-      child = spawn('cmd', ['/s', '/c', 'yarn', 'install', '--cwd', projectPath], {
-        stdio: 'inherit',
-      });
+    } else {
+      // windows
+      child = spawn(
+        'cmd',
+        ['/s', '/c', 'yarn', 'install', '--cwd', projectPath],
+        {
+          stdio: 'inherit',
+        }
+      );
     }
     child.on('close', code => {
       if (code !== 0) {

--- a/index.js
+++ b/index.js
@@ -113,9 +113,16 @@ async function compile(projectPath, templatePath, contentPath, ctx) {
 
 async function install(projectPath) {
   return new Promise((resolve, reject) => {
-    const child = spawn('yarn', ['install', '--cwd', projectPath], {
-      stdio: 'inherit',
-    });
+    let child;
+    if (!/^win/.test(process.platform)) { // linux
+      child = spawn('yarn', ['install', '--cwd', projectPath], {
+        stdio: 'inherit',
+      });
+    } else { // windows
+      child = spawn('cmd', ['/s', '/c', 'yarn', 'install', '--cwd', projectPath], {
+        stdio: 'inherit',
+      });
+    }
     child.on('close', code => {
       if (code !== 0) {
         reject(


### PR DESCRIPTION
This fix came from Jared Cuffe in the slack channel. I tested it on Windows 10 and it fixes the problem.

Original output:

```powershell
PS C:\Users\brandoncc\dev> yarn create fusion-app test-app
yarn create v1.1.0
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.4: The platform "win32" is incompatible with this module.
info "fsevents@1.2.4" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Installed "create-fusion-app@0.0.3" with binaries:
      - create-fusion-app
[#############################################################################################################] 319/319
Creating a new Fusion.js app in: C:\Users\brandoncc\dev/test-app

events.js:183
      throw er; // Unhandled 'error' event
      ^

Error: spawn yarn ENOENT
    at _errnoException (util.js:992:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:190:19)
    at onErrorNT (internal/child_process.js:372:16)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
error Command failed.
Exit code: 1
Command: C:\Users\brandoncc\AppData\Local\Yarn\bin\create-fusion-app
Arguments: test-app
Directory: C:\Users\brandoncc\dev
Output:

info Visit https://yarnpkg.com/en/docs/cli/create for documentation about this command.
```

After the fix:

```powershell
PS C:\Users\brandoncc\dev> .\node_modules\.bin\create-fusion-app test-app

Creating a new Fusion.js app in: C:\Users\brandoncc\dev/test-app

yarn install v1.1.0
warning package.json: No license field
warning example-fusion-app@0.0.0: No license field
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.4: The platform "win32" is incompatible with this module.
info "fsevents@1.2.4" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
warning "jest-environment-jsdom-global@1.1.0" has unmet peer dependency "jest-environment-jsdom@22.x || 23.x".
[4/4] Building fresh packages...
Done in 34.96s.

Success! You have created a Fusion.js project.

Start your Fusion.js app with:
  cd test-app && yarn dev
```